### PR TITLE
Issue 508: Use title image instead of list image on frontpage

### DIFF
--- a/ding_groups.module
+++ b/ding_groups.module
@@ -342,20 +342,20 @@ function ding_groups_preprocess_views_view_fields(&$vars) {
       switch ($count) {
         case '1';
           // One image.
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#max_style'] = 'ding_panorama_primary_large';
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#fallback_style'] = 'ding_panorama_primary_medium';
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#breakpoint_styles']['768'] = 'ding_panorama_primary_large';
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#breakpoint_styles']['500'] = 'ding_panorama_primary_medium';
-          $vars['fields']['field_ding_group_list_image']->content = drupal_render($vars['row']->field_field_ding_group_list_image[0]['rendered']);
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#max_style'] = 'ding_panorama_primary_large';
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#fallback_style'] = 'ding_panorama_primary_medium';
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#breakpoint_styles']['768'] = 'ding_panorama_primary_large';
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#breakpoint_styles']['500'] = 'ding_panorama_primary_medium';
+          $vars['fields']['field_ding_group_title_image']->content = drupal_render($vars['row']->field_field_ding_group_title_image[0]['rendered']);
           break;
 
         case '2';
           // Two image.
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#max_style'] = 'ding_panorama_primary_medium';
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#fallback_style'] = 'ding_panorama_primary_small';
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#breakpoint_styles']['768'] = 'ding_panorama_primary_medium';
-          $vars['row']->field_field_ding_group_list_image[0]['rendered']['#breakpoint_styles']['500'] = 'ding_panorama_primary_small';
-          $vars['fields']['field_ding_group_list_image']->content = drupal_render($vars['row']->field_field_ding_group_list_image[0]['rendered']);
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#max_style'] = 'ding_panorama_primary_medium';
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#fallback_style'] = 'ding_panorama_primary_small';
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#breakpoint_styles']['768'] = 'ding_panorama_primary_medium';
+          $vars['row']->field_field_ding_group_title_image[0]['rendered']['#breakpoint_styles']['500'] = 'ding_panorama_primary_small';
+          $vars['fields']['field_ding_group_title_image']->content = drupal_render($vars['row']->field_field_ding_group_title_image[0]['rendered']);
           break;
       }
     }

--- a/ding_groups.views_default.inc
+++ b/ding_groups.views_default.inc
@@ -240,17 +240,17 @@ function ding_groups_views_default_views() {
   $handler->display->display_options['fields']['title']['element_type'] = 'h2';
   $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
-  /* Field: Content: List image */
-  $handler->display->display_options['fields']['field_ding_group_list_image']['id'] = 'field_ding_group_list_image';
-  $handler->display->display_options['fields']['field_ding_group_list_image']['table'] = 'field_data_field_ding_group_list_image';
-  $handler->display->display_options['fields']['field_ding_group_list_image']['field'] = 'field_ding_group_list_image';
-  $handler->display->display_options['fields']['field_ding_group_list_image']['label'] = '';
-  $handler->display->display_options['fields']['field_ding_group_list_image']['element_type'] = '0';
-  $handler->display->display_options['fields']['field_ding_group_list_image']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_ding_group_list_image']['element_default_classes'] = FALSE;
-  $handler->display->display_options['fields']['field_ding_group_list_image']['click_sort_column'] = 'fid';
-  $handler->display->display_options['fields']['field_ding_group_list_image']['type'] = 'cs_adaptive_image';
-  $handler->display->display_options['fields']['field_ding_group_list_image']['settings'] = array(
+  /* Field: Content: Title image */
+  $handler->display->display_options['fields']['field_ding_group_title_image']['id'] = 'field_ding_group_title_image';
+  $handler->display->display_options['fields']['field_ding_group_title_image']['table'] = 'field_data_field_ding_group_title_image';
+  $handler->display->display_options['fields']['field_ding_group_title_image']['field'] = 'field_ding_group_title_image';
+  $handler->display->display_options['fields']['field_ding_group_title_image']['label'] = '';
+  $handler->display->display_options['fields']['field_ding_group_title_image']['element_type'] = '0';
+  $handler->display->display_options['fields']['field_ding_group_title_image']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_group_title_image']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_group_title_image']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_ding_group_title_image']['type'] = 'cs_adaptive_image';
+  $handler->display->display_options['fields']['field_ding_group_title_image']['settings'] = array(
     'image_link' => 'content',
     'styles' => array(
       'breakpoint_1' => '768',


### PR DESCRIPTION
List images fit much better in resolution and width/height ratio.

This also prevents upscaling of images.

Issue: http://platform.dandigbib.org/issues/508
