### PR TITLE
Issue 1142: Add new node queue for managing front page groups.

### DIFF
--- a/ding_groups.install
+++ b/ding_groups.install
@@ -30,7 +30,8 @@ function ding_groups_uninstall() {
 function ding_groups_install_nodequeues() {
   foreach (ding_groups_nodequeues() as $queue) {
     // Only save the nodequeue if it does not exist already.
-    if (empty(nodequeue_load_queue_by_name($queue->name))) {
+    $existing_queue = nodequeue_load_queue_by_name($queue->name);
+    if (empty($existing_queue)) {
       nodequeue_save($queue);
     }
   }

--- a/ding_groups.install
+++ b/ding_groups.install
@@ -11,29 +11,46 @@
  * Implements hook_install().
  */
 function ding_groups_install() {
-  ding_groups_install_nodequeue();
+  ding_groups_install_nodequeues();
 }
 
 /**
  * Implements hook_uninstall().
  */
 function ding_groups_uninstall() {
-  $queue = nodequeue_load_queue_by_name('ding_groups_listning');
-  nodequeue_delete($queue->qid);
+  foreach (ding_groups_nodequeues() as $queue) {
+    $queue = nodequeue_load_queue_by_name($queue->name);
+    nodequeue_delete($queue->qid);
+  }
 }
 
 /**
- * Helper function to create node queue used in groups listing pages.
+ * Helper function to create node queues.
  */
-function ding_groups_install_nodequeue() {
+function ding_groups_install_nodequeues() {
+  foreach (ding_groups_nodequeues() as $queue) {
+    // Only save the nodequeue if it does not exist already.
+    if (empty(nodequeue_load_queue_by_name($queue->name))) {
+      nodequeue_save($queue);
+    }
+  }
+}
+
+/**
+ * Definition of all nodequeues used by this module.
+ *
+ * Each definition should contain enough information that it can be passed to
+ * nodequeue_save() to persist the nodequeue.
+ *
+ * @return array
+ *   An array of objects each defining a nodequeue.
+ */
+function ding_groups_nodequeues() {
+  // First a template for all nodequeues defined here.
   $nodequeue = new stdClass();
-  $nodequeue->name = 'ding_groups_listning';
-  $nodequeue->title = 'Groups listing';
   $nodequeue->subqueue_title = '';
   $nodequeue->owner = 'nodequeue';
   $nodequeue->api_version = 2;
-  $nodequeue->link = 'Add to listing';
-  $nodequeue->link_remove = 'Remove from listing';
   $nodequeue->show_in_ui = TRUE;
   $nodequeue->show_in_tab = TRUE;
   $nodequeue->show_in_links = FALSE;
@@ -49,11 +66,26 @@ function ding_groups_install_nodequeue() {
   $nodequeue->submit = 'Submit';
   $nodequeue->reverse = 0;
   $nodequeue->reference = 0;
-  $nodequeue->add_subqueue = array(
-    $nodequeue->title,
+
+  $listing = clone $nodequeue;
+  $listing->name = 'ding_groups_listning';
+  $listing->title = 'Groups listing';
+  $listing->link = 'Add to listing';
+  $listing->link_remove = 'Remove from listing';
+  $listing->add_subqueue = array(
+    $listing->title,
   );
 
-  nodequeue_save($nodequeue);
+  $frontpage_listing = clone $nodequeue;
+  $frontpage_listing->name = 'ding_groups_frontpage_listing';
+  $frontpage_listing->title = 'Front page groups listing';
+  $frontpage_listing->link = 'Add to front page listing';
+  $frontpage_listing->link_remove = 'Remove from front page listing';
+  $frontpage_listing->add_subqueue = array(
+    $frontpage_listing->title,
+  );
+
+  return array($listing, $frontpage_listing);
 }
 
 /**
@@ -62,7 +94,7 @@ function ding_groups_install_nodequeue() {
 function ding_groups_update_7001() {
   $qids = nodequeue_get_qids('ding_group');
   if (empty($qids)) {
-    ding_groups_install_nodequeue();
+    ding_groups_install_nodequeues();
   }
 }
 
@@ -71,4 +103,47 @@ function ding_groups_update_7001() {
  */
 function ding_groups_update_7002() {
   ding_groups_install_menu_position();
+}
+
+/**
+ * Install front page groups listing queue and populate it.
+ */
+function ding_groups_update_7003() {
+  ding_groups_install_nodequeues();
+
+  // Populate new front page listing with the nodes that would have appeared in
+  // it previously: Nodes in the existing groups listing queue which are
+  // promoted to the front page.
+
+  // First retrieve an updated list of nodequeue names and ids. We cannot use
+  // nodequeue_load_queue_by_name() as it uses a static cache of nodequeue
+  // names. This cache will not contain the newly created queue and there is no
+  // way to reset it.
+  $queue_name_ids = array();
+  $result = db_query("SELECT qid, name FROM {nodequeue_queue}");
+  while ($get = $result->fetchObject()) {
+    $queue_name_ids[$get->name] = $get->qid;
+  }
+
+  // Load new queue and subqueues. Both are needed to support inserting content.
+  $frontpage_listing_queue = nodequeue_load($queue_name_ids['ding_groups_frontpage_listing']);
+  $frontpage_listing_subqueues = nodequeue_load_subqueues_by_queue($frontpage_listing_queue->qid);
+  $frontpage_listing_subqueue = reset($frontpage_listing_subqueues);
+
+  // Load existing subqueue for groups listing.
+  $subqueues = nodequeue_load_subqueues_by_queue($queue_name_ids['ding_groups_listning']);
+  $subqueue = reset($subqueues);
+  // Load all nodes in the existing queue without using pagination.
+  $nodes = nodequeue_load_nodes($subqueue->sqid, NULL, NULL, FALSE);
+  foreach ($nodes as $node) {
+    // If a node in the queue is promoted to the frontpage then add it to the
+    // new queue.
+    if ($node->promote) {
+      nodequeue_subqueue_add($frontpage_listing_queue, $frontpage_listing_subqueue, $node->nid);
+      // The node should no longer be promoted to the front page. The new queue
+      // supersedes this flag.
+      $node->promote = 0;
+      node_save($node);
+    }
+  }
 }

--- a/ding_groups.views_default.inc
+++ b/ding_groups.views_default.inc
@@ -229,6 +229,20 @@ function ding_groups_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Nodequeue: Queue */
+  $handler->display->display_options['relationships']['nodequeue_rel']['id'] = 'nodequeue_rel';
+  $handler->display->display_options['relationships']['nodequeue_rel']['table'] = 'node';
+  $handler->display->display_options['relationships']['nodequeue_rel']['field'] = 'nodequeue_rel';
+  $handler->display->display_options['relationships']['nodequeue_rel']['label'] = 'Queue';
+  $handler->display->display_options['relationships']['nodequeue_rel']['required'] = TRUE;
+  $handler->display->display_options['relationships']['nodequeue_rel']['limit'] = 1;
+  $handler->display->display_options['relationships']['nodequeue_rel']['names'] = array(
+    'ding_groups_frontpage_listing' => 'ding_groups_frontpage_listing',
+    'ding_library_listing' => 0,
+    'ding_groups_listning' => 0,
+    'ding_tabroll_frontpage' => 0,
+  );
   $handler->display->display_options['defaults']['fields'] = FALSE;
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
@@ -302,11 +316,6 @@ function ding_groups_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'ding_group' => 'ding_group',
   );
-  /* Filter criterion: Content: Promoted to front page */
-  $handler->display->display_options['filters']['promote']['id'] = 'promote';
-  $handler->display->display_options['filters']['promote']['table'] = 'node';
-  $handler->display->display_options['filters']['promote']['field'] = 'promote';
-  $handler->display->display_options['filters']['promote']['value'] = '1';
   $handler->display->display_options['pane_category']['name'] = 'Groups panes';
   $handler->display->display_options['pane_category']['weight'] = '0';
   $translatables['ding_groups'] = array(
@@ -331,6 +340,7 @@ function ding_groups_views_default_views() {
     t('Simply list all groups'),
     t('Groups panes'),
     t('Front page groups listing'),
+    t('Queue'),
   );
   $export['ding_groups'] = $view;
 


### PR DESCRIPTION
- Refactor ding group node queue handling to support multiple groups
- Add new front page groups node queue
- Populate new queue with content from existing queue that has been promoted to front page
- Update front page groups view to use new node queue.
- Remove dependency on promoted to front page flag

Issue: http://platform.dandigbib.org/issues/1142
