### PR TITLE
Issue #287 - Move campaign panes to left column.

### DIFF
--- a/ding_groups.pages_default.inc
+++ b/ding_groups.pages_default.inc
@@ -179,7 +179,7 @@ function ding_groups_default_page_manager_handlers() {
     $display->panels['main_content'][2] = 'new-3bc42ce7-ca5f-4e5c-9176-2bcbaecc961a';
     $pane = new stdClass();
     $pane->pid = 'new-c9969c72-cf63-49ed-b371-61bb19780890';
-    $pane->panel = 'right_sidebar';
+    $pane->panel = 'left_sidebar';
     $pane->type = 'campaign';
     $pane->subtype = 'campaign';
     $pane->shown = TRUE;
@@ -207,7 +207,7 @@ function ding_groups_default_page_manager_handlers() {
     $pane->locks = array();
     $pane->uuid = 'c9969c72-cf63-49ed-b371-61bb19780890';
     $display->content['new-c9969c72-cf63-49ed-b371-61bb19780890'] = $pane;
-    $display->panels['right_sidebar'][0] = 'new-c9969c72-cf63-49ed-b371-61bb19780890';
+    $display->panels['left_sidebar'][0] = 'new-c9969c72-cf63-49ed-b371-61bb19780890';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;
@@ -708,7 +708,7 @@ function ding_groups_default_page_manager_pages() {
     $display->panels['main_content'][0] = 'new-f5c30667-761e-4d84-95e3-d5d724581160';
     $pane = new stdClass();
     $pane->pid = 'new-e806ff55-7233-4b24-9383-43f9025629a6';
-    $pane->panel = 'right_sidebar';
+    $pane->panel = 'left_sidebar';
     $pane->type = 'campaign';
     $pane->subtype = 'campaign';
     $pane->shown = TRUE;
@@ -736,7 +736,7 @@ function ding_groups_default_page_manager_pages() {
     $pane->locks = array();
     $pane->uuid = 'e806ff55-7233-4b24-9383-43f9025629a6';
     $display->content['new-e806ff55-7233-4b24-9383-43f9025629a6'] = $pane;
-    $display->panels['right_sidebar'][0] = 'new-e806ff55-7233-4b24-9383-43f9025629a6';
+    $display->panels['left_sidebar'][0] = 'new-e806ff55-7233-4b24-9383-43f9025629a6';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = 'new-f5c30667-761e-4d84-95e3-d5d724581160';
   $handler->conf['display'] = $display;

--- a/ding_groups.pages_default.inc
+++ b/ding_groups.pages_default.inc
@@ -203,11 +203,11 @@ function ding_groups_default_page_manager_handlers() {
     );
     $pane->css = array();
     $pane->extras = array();
-    $pane->position = 0;
+    $pane->position = 1;
     $pane->locks = array();
     $pane->uuid = 'c9969c72-cf63-49ed-b371-61bb19780890';
     $display->content['new-c9969c72-cf63-49ed-b371-61bb19780890'] = $pane;
-    $display->panels['left_sidebar'][0] = 'new-c9969c72-cf63-49ed-b371-61bb19780890';
+    $display->panels['left_sidebar'][1] = 'new-c9969c72-cf63-49ed-b371-61bb19780890';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;


### PR DESCRIPTION
Within the task of refactoring the [`ding_campaign`](https://github.com/ding2/ding_campaign) module, it has been discovered that the current campaign panes is located in the right side of the layout on several panels.

Even though the module is not activated/working in DDB CMS, the panes are added as inaccessible on the layouts which means that if someone should activate the module, the layout will be broken due to the narrow middle column.

Issue: http://platform.dandigbib.org/issues/287.
